### PR TITLE
Feature/fix admin client scheduler

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/AdminClientServiceImpl.java
+++ b/api/src/main/java/io/kafbat/ui/service/AdminClientServiceImpl.java
@@ -52,8 +52,7 @@ public class AdminClientServiceImpl implements AdminClientService, Closeable {
           "kafbat-ui-admin-" + Instant.now().getEpochSecond() + "-" + CLIENT_ID_SEQ.incrementAndGet()
       );
       return AdminClient.create(properties);
-    }))
-        .flatMap(ac -> ReactiveAdminClient.create(ac).doOnError(th -> ac.close()))
+    })).flatMap(ac -> ReactiveAdminClient.create(ac).doOnError(th -> ac.close()))
         .onErrorMap(th -> new IllegalStateException(
             "Error while creating AdminClient for the cluster " + cluster.getName(), th));
   }

--- a/api/src/main/java/io/kafbat/ui/service/AdminClientServiceImpl.java
+++ b/api/src/main/java/io/kafbat/ui/service/AdminClientServiceImpl.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,8 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 @Service
 @Slf4j
@@ -40,7 +43,7 @@ public class AdminClientServiceImpl implements AdminClientService, Closeable {
   }
 
   private Mono<ReactiveAdminClient> createAdminClient(KafkaCluster cluster) {
-    return Mono.fromSupplier(() -> {
+    return Mono.fromFuture(CompletableFuture.supplyAsync(() -> {
       Properties properties = new Properties();
       KafkaClientSslPropertiesUtil.addKafkaSslProperties(cluster.getOriginalProperties().getSsl(), properties);
       properties.putAll(cluster.getProperties());
@@ -51,7 +54,8 @@ public class AdminClientServiceImpl implements AdminClientService, Closeable {
           "kafbat-ui-admin-" + Instant.now().getEpochSecond() + "-" + CLIENT_ID_SEQ.incrementAndGet()
       );
       return AdminClient.create(properties);
-    }).flatMap(ac -> ReactiveAdminClient.create(ac).doOnError(th -> ac.close()))
+    }))
+        .flatMap(ac -> ReactiveAdminClient.create(ac).doOnError(th -> ac.close()))
         .onErrorMap(th -> new IllegalStateException(
             "Error while creating AdminClient for the cluster " + cluster.getName(), th));
   }

--- a/api/src/main/java/io/kafbat/ui/service/AdminClientServiceImpl.java
+++ b/api/src/main/java/io/kafbat/ui/service/AdminClientServiceImpl.java
@@ -16,8 +16,6 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 @Service
 @Slf4j


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
I identified a bug where Event Hub with Kafka protocol and Entra authentication does not work because.block() is being called in a parallel scheduler thread, which throws an exception. Creating the Admin client using Mono.supplier() runs on the parallel scheduler. Creating the admin client using a CompletableFuture eliminates this problem because CompletableFutures are run on different threads.

Here is the bug:
![kafka-ui-bug](https://github.com/user-attachments/assets/6c30fcd8-7857-4f2e-a81e-b7200c5e1ae9)

Here is the result after the fix:
![image](https://github.com/user-attachments/assets/505ca3cb-78de-4133-b2df-8752a1d15a54)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary) - After making the change, I started Kafka UI and connected to an Azure Event Hub Cluster using Kafka protocol and Entra authentication. I can now list topics.
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Red_Panda_%2824986761703%29.jpg/1200px-Red_Panda_%2824986761703%29.jpg)
